### PR TITLE
chore(nix): add flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746232882,
+        "narHash": "sha256-MHmBH2rS8KkRRdoU/feC/dKbdlMkcNkB5mwkuipVHeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7a2622e2c0dbad5c4493cb268aba12896e28b008",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1746326315,
+        "narHash": "sha256-IDqSls/r6yBfdOBRSMQ/noTUoigmsKnTQ7TqpsBtN4Y=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "dd280c436961ec5adccf0135efe5b66a23d84497",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; }
+      {
+        systems = [
+          "x86_64-linux"
+          "aarch64-linux"
+        ];
+
+        perSystem = { self', lib, system, pkgs, config, ... }: {
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+
+            overlays = with inputs; [
+              rust-overlay.overlays.default
+            ];
+          };
+
+          packages = rec {
+            default = cargo-nfpm;
+            cargo-nfpm = pkgs.callPackage (import ./nix/package.nix) { };
+          };
+
+          devShells =
+            let
+              rust-toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+            in
+            {
+              default =
+                let
+                  package = pkgs.callPackage (import ./nix/package.nix) { };
+                in
+                pkgs.mkShell {
+                  packages = with pkgs; [
+                  ] ++ [ rust-toolchain ];
+
+                  buildInputs = package.buildInputs;
+                  nativeBuildInputs = package.nativeBuildInputs;
+
+                  LD_LIBRARY_PATH = package.LD_LIBRARY_PATH;
+                };
+            };
+        };
+      };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,37 @@
+{ rustPlatform
+, lib
+, pkg-config
+, nfpm
+}:
+let
+  cargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+in
+rustPlatform.buildRustPackage rec {
+  pname = cargoToml.package.name;
+  version = cargoToml.package.version;
+
+  src = builtins.path {
+    path = ../.;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  buildInputs = [
+    nfpm
+  ];
+
+  doCheck = false;
+
+  LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+  CARGO_NFPM_BIN = lib.makeBinPath [ nfpm ];
+
+  cargoLock.lockFile = ../Cargo.lock;
+
+  meta = {
+    description = cargoToml.package.description;
+    homepage = cargoToml.package.homepage;
+    license = with lib.licenses; [ mit asl20 ];
+    mainProgram = pname;
+  };
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rust-analyzer"]


### PR DESCRIPTION
This allows nix users to directly use `cargo-nfpm`.